### PR TITLE
Fix domain parameter, change expiration to string

### DIFF
--- a/ElasticBurp.py
+++ b/ElasticBurp.py
@@ -294,10 +294,10 @@ class BurpExtender(IBurpExtender, IHttpListener, IContextMenuFactory, ITab):
                 expiration = None
                 if expCookie:
                     try:
-                        expiration = datetime.fromtimestamp(expCookie.time / 1000)
+                        expiration = str(datetime.fromtimestamp(expCookie.time / 1000))
                     except:
                         pass
-                doc.add_response_cookie(cookie.getName(), cookie.getValue(), cookie.getExpiration(), cookie.getPath(), expiration)
+                doc.add_response_cookie(cookie.getName(), cookie.getValue(), cookie.getDomain(), cookie.getPath(), expiration)
 
             bodyOffset = iResponse.getBodyOffset()
             doc.response.body = response[bodyOffset:].tostring().decode("ascii", "replace")


### PR DESCRIPTION
Expiration was being sent instead of Domain for Cookie parsing.  For actual expiration cookie was being sent as datetime object, not string.

Example cookie being sent to ES.
{'path': u'/', 'domain': Wed Feb 08 21:57:20 EST 2017, 'name': u'fooName', 'expiration': datetime.datetime(2017, 2, 8, 21, 57, 20), 'value': u'fooValue'}