### PR TITLE
Added support for version 7.0.0

### DIFF
--- a/ElasticBurp.py
+++ b/ElasticBurp.py
@@ -33,7 +33,7 @@ except:
 reDateHeader = re.compile("^Date:\s*(.*)$", flags=re.IGNORECASE)
 
 ### Config (TODO: move to config tab) ###
-ES_host = "localhost"
+ES_host = "vmhost.fake"
 ES_index = "wase-burp"
 Burp_Tools = IBurpExtenderCallbacks.TOOL_PROXY
 Burp_onlyResponses = True       # Usually what you want, responses also contain requests
@@ -68,7 +68,7 @@ class BurpExtender(IBurpExtender, IHttpListener, IContextMenuFactory, ITab):
             print("Connecting to '%s', index '%s'" % (self.confESHost, self.confESIndex))
             self.es = connections.create_connection(hosts=[self.confESHost])
             self.idx = Index(self.confESIndex)
-            self.idx.doc_type(DocHTTPRequestResponse)
+            self.idx.document(DocHTTPRequestResponse)
             if self.idx.exists():
                 self.idx.open()
             else:

--- a/ElasticBurp.py
+++ b/ElasticBurp.py
@@ -33,7 +33,7 @@ except:
 reDateHeader = re.compile("^Date:\s*(.*)$", flags=re.IGNORECASE)
 
 ### Config (TODO: move to config tab) ###
-ES_host = "vmhost.fake"
+ES_host = "localhost"
 ES_index = "wase-burp"
 Burp_Tools = IBurpExtenderCallbacks.TOOL_PROXY
 Burp_onlyResponses = True       # Usually what you want, responses also contain requests

--- a/WASEProxy.py
+++ b/WASEProxy.py
@@ -26,7 +26,7 @@ class WASEProxyHandler(ProxyHandler):
 	# Initialize ES connection and index
 	res = connections.create_connection(hosts=[args.elasticsearch])
 	idx = Index(args.index)
-	idx.doc_type(DocHTTPRequestResponse)
+	idx.document(DocHTTPRequestResponse)
 	try:
 	    DocHTTPRequestResponse.init()
 	    idx.create()

--- a/requirements-proxy.txt
+++ b/requirements-proxy.txt
@@ -1,7 +1,0 @@
-cryptography==1.8.1
-elasticsearch==5.1.0
-elasticsearch-dsl==5.1.0
-pymiproxy==1.0
-pyparsing==2.2.0
-six==1.10.0
-tzlocal==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-elasticsearch==5.1.0
-elasticsearch-dsl==5.1.0
-tzlocal==1.3

--- a/test.py
+++ b/test.py
@@ -6,7 +6,7 @@ from datetime import datetime
 connections.create_connection(hosts=["localhost"])
 
 idx = Index("test")
-idx.doc_type(DocHTTPRequestResponse)
+idx.document(DocHTTPRequestResponse)
 #idx.create()
 
 DocHTTPRequestResponse.init()


### PR DESCRIPTION
With these changes the code works with the newer version of ElasticSearch version 7.0.0.
The requirement files need to be changed to install the proper dependencies.